### PR TITLE
translation for German strings

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -21,9 +21,9 @@ https://github.com/known-as-bmf/plugin.video.arteplussept
         </description>
         <description lang="de">
 Sehen Sie Videos von Arte +7
-For feature requests / issues:
+Für Fehlerberichte und Verbesserungsvorschläge:
 https://github.com/known-as-bmf/plugin.video.arteplussept/issues
-Contributions are welcome:
+Mithilfe ist willkommen:
 https://github.com/known-as-bmf/plugin.video.arteplussept
         </description>
         <description lang="en">

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -3,29 +3,29 @@
     <string id="30000">Arte +7</string>
 
     <!-- menu items & misc messages -->
-    <string id="30001">Alle videos</string>
-    <string id="30002">Selection</string>
+    <string id="30001">Alle Videos</string>
+    <string id="30002">Auswahl</string>
     <string id="30003">Meistgesehen</string>
-    <string id="30004">Letzte chance</string>
+    <string id="30004">Letzte Chance</string>
     <string id="30005">Themen</string>
     <string id="30005">Live</string>
 
-    <string id="30007">Downloading</string>
-    <string id="30008">Done downloading</string>
-    <string id="30009">Error</string>
-    <string id="30010">Please set a download folder in the settings</string>
+    <string id="30007">Lädt herunter</string>
+    <string id="30008">Fertig heruntergeladen</string>
+    <string id="30009">Fehler</string>
+    <string id="30010">Bitte wählen Sie ein Downloadverzeichnis in den Einstellungen</string>
 
     <!-- context menu -->
-    <string id="30020">Add to queue</string>
-    <string id="30021">Download video</string>
+    <string id="30020">Zur Warteschlange hinzufügen</string>
+    <string id="30021">Video herunterladen</string>
 
     <!-- options -->
-    <string id="30050">Language (Videos)</string>
-    <string id="30051">Prefer original versions</string>
-    <string id="30052">Stream video quality</string>
-    <string id="30053">Streaming protocol</string>
-    <string id="30054">Download directory</string>
-    <string id="30055">Download video quality</string>
+    <string id="30050">Sprache (Videos)</string>
+    <string id="30051">Bevorzuge Orginalfassung</string>
+    <string id="30052">Qualität des Videostreams</string>
+    <string id="30053">Streamingprotokol</string>
+    <string id="30054">Downloadverzeichnis</string>
+    <string id="30055">Videoqualität der Downloads</string>
 
     <!-- themes -->
     <string id="3000501">Aktuelles</string>


### PR DESCRIPTION
This translates the missing German strings and the short description in addons.xml.

I'm not sure if my translation of string 30002 "Selection" as "Auswahl"
is accurate, as I don't know if there is some "official" translation of
it on the Arte website. At least I didn't find one...