### PR TITLE
Video information on the right side

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -176,7 +176,7 @@ def show_listing():
         }
         # item['context_menu'].append((plugin.get_string(30020), plugin.url_for('enqueue', item=item)))
         items.append(item)
-    return plugin.finish(items)
+    return plugin.finish(items, view_mode = 504)
 
 
 @plugin.route('/categories', name='categories')

--- a/addon.py
+++ b/addon.py
@@ -114,6 +114,7 @@ quality = plugin.get_setting('quality', int)
 protocol = 'HBBTV' if plugin.get_setting('protocol', int) == 0 else 'RMP4'
 download_folder = plugin.get_setting('download_folder', str)
 download_quality = plugin.get_setting('download_quality', int)
+view_mode = 504 if plugin.get_setting( "show_info", bool ) == True else None
 
 
 @plugin.route('/')
@@ -176,7 +177,7 @@ def show_listing():
         }
         # item['context_menu'].append((plugin.get_string(30020), plugin.url_for('enqueue', item=item)))
         items.append(item)
-    return plugin.finish(items, view_mode = 504)
+    return plugin.finish(items, view_mode = view_mode)
 
 
 @plugin.route('/categories', name='categories')

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -26,6 +26,7 @@
     <string id="30053">Streaming protocol</string>
     <string id="30054">Download directory</string>
     <string id="30055">Download video quality</string>
+    <string id="30056">Show video informations</string>
 
     <!-- categories -->
     <string id="3000501">News &amp; society</string>

--- a/resources/language/French/strings.xml
+++ b/resources/language/French/strings.xml
@@ -26,6 +26,7 @@
     <string id="30053">Protocole de streaming</string>
     <string id="30054">Répertoire de téléchargement</string>
     <string id="30055">Qualité des vidéos téléchargées</string>
+    <string id="30056">Show video informations</string>
 
     <!-- categories -->
     <string id="3000501">Actu &amp; société</string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -26,6 +26,7 @@
     <string id="30053">Streamingprotokol</string>
     <string id="30054">Downloadverzeichnis</string>
     <string id="30055">Videoqualität der Downloads</string>
+    <string id="30056">Video Informationen anzeigen</string>
 
     <!-- categories -->
     <string id="3000501">Aktuelles &amp; Gesellschaft</string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -10,10 +10,10 @@
     <string id="30005">Themen</string>
     <string id="30005">Live</string>
 
-    <string id="30007">Lädt herunter</string>
+    <string id="30007">Laedt herunter</string>
     <string id="30008">Fertig heruntergeladen</string>
     <string id="30009">Fehler</string>
-    <string id="30010">Bitte wählen Sie ein Downloadverzeichnis in den Einstellungen</string>
+    <string id="30010">Bitte waehlen Sie ein Downloadverzeichnis in den Einstellungen</string>
 
     <!-- context menu -->
     <string id="30020">Zur Warteschlange hinzufügen</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,4 +6,5 @@
     <setting id="protocol"         type="enum"   label="30053" values="HTTP|RTMP" default="0"/>
     <setting id="download_folder"  type="folder" label="30054" source="auto" option="writeable"/>
     <setting id="download_quality" type="enum"   label="30055" values="SQ (High)|EQ (Medium)|HQ (Low)|MQ (Very Low)" default="0"/>
+    <setting id="show_info"       type="bool" label="30056" default="true"/>
 </settings>


### PR DESCRIPTION
My changes:

1. Show the video information on the right side, not only in the info view.
2. Download function: not working, because an Unicode errors was logged.
3. Show video information configurable in the plugin setup ( see nr 1 )

Best regards
Herbert