### PR TITLE
Add new folders in the main menu: "Newest", "Most viewed" and "Last chance"

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -17,3 +17,15 @@ msgstr "Sprache (Videos)"
 msgctxt "#30052"
 msgid "Stream video quality"
 msgstr "Qualität des Videostreams"
+
+msgctxt "#30005"
+msgid "Most recent"
+msgstr "Neuste"
+
+msgctxt "#30006"
+msgid "Most viewed"
+msgstr "Am meisten gesehen"
+
+msgctxt "#30007"
+msgid "Last chance"
+msgstr "Letzte chance"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -17,3 +17,15 @@ msgstr ""
 msgctxt "#30052"
 msgid "Stream video quality"
 msgstr ""
+
+msgctxt "#30005"
+msgid "Most recent"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Most viewed"
+msgstr ""
+
+msgctxt "#30007"
+msgid "Last chance"
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -17,3 +17,15 @@ msgstr "Langage (Vidéos)"
 msgctxt "#30052"
 msgid "Stream video quality"
 msgstr "Qualité vidéo préferée"
+
+msgctxt "#30005"
+msgid "Most recent"
+msgstr "Les plus récentes"
+
+msgctxt "#30006"
+msgid "Most viewed"
+msgstr "Les plus vues"
+
+msgctxt "#30007"
+msgid "Last chance"
+msgstr "Dernière chance"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -66,6 +66,24 @@ def magazines():
     return plugin.finish(view.build_magazines(language))
 
 
+@plugin.route('/newest', name='newest')
+def newest():
+    plugin.set_content('tvshows')
+    return plugin.finish(view.build_newest(language))
+
+
+@plugin.route('/most_viewed', name='most_viewed')
+def most_viewed():
+    plugin.set_content('tvshows')
+    return plugin.finish(view.build_most_viewed(language))
+
+
+@plugin.route('/last_chance', name='last_chance')
+def last_chance():
+    plugin.set_content('tvshows')
+    return plugin.finish(view.build_last_chance(language))
+
+
 @plugin.route('/sub_category/<sub_category_code>', name='sub_category_by_code')
 def sub_category_by_code(sub_category_code):
     plugin.set_content('tvshows')

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -8,32 +8,29 @@ _base_headers = {
     'user-agent': PluginInformation.name + '/' + PluginInformation.version
 }
 _endpoints = {
-    'categories': '/EMAC/teasers/categories/v2/{lang}',
+    'categories': '/EMAC/teasers/{type}/v2/{lang}',
     'category': '/EMAC/teasers/category/v2/{category_code}/{lang}',
     'subcategory': '/OPA/v3/videos/subcategory/{sub_category_code}/page/1/limit/100/{lang}',
     'magazines': '/OPA/v3/magazines/{lang}',
     'collection': '/OPA/v3/videos/collection/{kind}/{collection_id}/{lang}',
     'streams': '/OPA/v3/streams/{program_id}/{kind}/{lang}',
-    'home': '/EMAC/teasers/home/v2/{lang}',
-
-
     'daily': '/OPA/v3/programs/{date}/{lang}'
 }
 
 
 def categories(lang):
-    url = _endpoints['categories'].format(lang=lang)
+    url = _endpoints['categories'].format(type='categories', lang=lang)
     return _load_json(url).get('categories', {})
+
+
+def home_category(name, lang):
+    url = _endpoints['categories'].format(type='home', lang=lang)
+    return _load_json(url).get('teasers', {}).get(name, [])
 
 
 def magazines(lang):
     url = _endpoints['magazines'].format(lang=lang)
     return _load_json(url).get('magazines', {})
-
-
-def home_categories(name, lang):
-    url = _endpoints['home'].format(category_code='home', lang=lang)
-    return _load_json(url).get('teasers', {}).get(name, [])
 
 
 def category(category_code, lang):

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -30,6 +30,14 @@ def magazines(lang):
     return _load_json(url).get('magazines', {})
 
 
+def special_categories(name, lang):
+    url = _endpoints['category'].format(category_code=name, lang=lang)
+    cat = _load_json(url).get('category', [])
+    if cat:
+        return cat[0].get('teasers', [])
+    return []
+
+
 def category(category_code, lang):
     url = _endpoints['category'].format(category_code=category_code, lang=lang)
     return _load_json(url).get('category', {})

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -14,6 +14,7 @@ _endpoints = {
     'magazines': '/OPA/v3/magazines/{lang}',
     'collection': '/OPA/v3/videos/collection/{kind}/{collection_id}/{lang}',
     'streams': '/OPA/v3/streams/{program_id}/{kind}/{lang}',
+    'home': '/EMAC/teasers/home/v2/{lang}',
 
 
     'daily': '/OPA/v3/programs/{date}/{lang}'
@@ -30,12 +31,9 @@ def magazines(lang):
     return _load_json(url).get('magazines', {})
 
 
-def special_categories(name, lang):
-    url = _endpoints['category'].format(category_code=name, lang=lang)
-    cat = _load_json(url).get('category', [])
-    if cat:
-        return cat[0].get('teasers', [])
-    return []
+def home_categories(name, lang):
+    url = _endpoints['home'].format(category_code='home', lang=lang)
+    return _load_json(url).get('teasers', {}).get(name, [])
 
 
 def category(category_code, lang):

--- a/resources/lib/mapper.py
+++ b/resources/lib/mapper.py
@@ -32,6 +32,27 @@ def create_week_item():
     }
 
 
+def create_newest_item():
+    return {
+        'label': plugin.addon.getLocalizedString(30005),
+        'path': plugin.url_for('newest')
+    }
+
+
+def create_most_viewed_item():
+    return {
+        'label': plugin.addon.getLocalizedString(30006),
+        'path': plugin.url_for('most_viewed')
+    }
+
+
+def create_last_chance_item():
+    return {
+        'label': plugin.addon.getLocalizedString(30007),
+        'path': plugin.url_for('last_chance')
+    }
+
+
 def map_category_item(item, category_code):
     code = item.get('code')
     title = item.get('title')

--- a/resources/lib/mapper.py
+++ b/resources/lib/mapper.py
@@ -98,7 +98,7 @@ def map_video(config):
             'title': config.get('title'),
             'duration': duration,
             'genre': config.get('genrePresse'),
-            'plot': config.get('shortDescription'),
+            'plot': config.get('shortDescription') or config.get('fullDescription'),
             'plotoutline': config.get('teaserText'),
             # year is not correctly used by kodi :(
             # the aired year will be used by kodi for production year :(

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -6,10 +6,11 @@ import utils
 
 
 def build_categories(lang):
-    categories = []
-    categories.append(mapper.create_newest_item())
-    categories.append(mapper.create_most_viewed_item())
-    categories.append(mapper.create_last_chance_item())
+    categories = [
+        mapper.create_newest_item(),
+        mapper.create_most_viewed_item(),
+        mapper.create_last_chance_item(),
+    ]
     categories.extend([mapper.map_categories_item(
         item) for item in api.categories(lang)])
     categories.append(mapper.create_creative_item())
@@ -21,17 +22,17 @@ def build_categories(lang):
 
 def build_newest(lang):
     return [mapper.map_generic_item(item) for
-            item in api.home_categories('mostRecent', lang)]
+            item in api.home_category('mostRecent', lang)]
 
 
 def build_most_viewed(lang):
     return [mapper.map_generic_item(item) for
-            item in api.home_categories('mostViewed', lang)]
+            item in api.home_category('mostViewed', lang)]
 
 
 def build_last_chance(lang):
     return [mapper.map_generic_item(item) for
-            item in api.home_categories('lastChance', lang)]
+            item in api.home_category('lastChance', lang)]
 
 
 def build_magazines(lang):

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -6,13 +6,32 @@ import utils
 
 
 def build_categories(lang):
-    categories = [mapper.map_categories_item(
-        item) for item in api.categories(lang)]
+    categories = []
+    categories.append(mapper.create_newest_item())
+    categories.append(mapper.create_most_viewed_item())
+    categories.append(mapper.create_last_chance_item())
+    categories.extend([mapper.map_categories_item(
+        item) for item in api.categories(lang)])
     categories.append(mapper.create_creative_item())
     categories.append(mapper.create_magazines_item())
     categories.append(mapper.create_week_item())
 
     return categories
+
+
+def build_newest(lang):
+    return [mapper.map_generic_item(item) for
+            item in api.special_categories('MOST_RECENT', lang)]
+
+
+def build_most_viewed(lang):
+    return [mapper.map_generic_item(item) for
+            item in api.special_categories('MOST_VIEWED', lang)]
+
+
+def build_last_chance(lang):
+    return [mapper.map_generic_item(item) for
+            item in api.special_categories('LAST_CHANCE', lang)]
 
 
 def build_magazines(lang):

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -21,17 +21,17 @@ def build_categories(lang):
 
 def build_newest(lang):
     return [mapper.map_generic_item(item) for
-            item in api.special_categories('MOST_RECENT', lang)]
+            item in api.home_categories('mostRecent', lang)]
 
 
 def build_most_viewed(lang):
     return [mapper.map_generic_item(item) for
-            item in api.special_categories('MOST_VIEWED', lang)]
+            item in api.home_categories('mostViewed', lang)]
 
 
 def build_last_chance(lang):
     return [mapper.map_generic_item(item) for
-            item in api.special_categories('LAST_CHANCE', lang)]
+            item in api.home_categories('lastChance', lang)]
 
 
 def build_magazines(lang):


### PR DESCRIPTION
This PR adds three new folders to the main menu of the plugin: "Newest" (which contains a list of the most recent ARTE videos), "Most viewed" (which contains a list of the most viewed videos) and "Last chance" (which contains a list of videos that will soon be offline). So this PR allows the user of the plugin to browse through the ARTE videos in a more natural way.

Caveat: The API request does not return any deeper information about the videos, so there won't be any video description available for the videos in these three folders.