### PR TITLE
[Audio] Adding option to play VOST videos

### DIFF
--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -17,3 +17,8 @@ msgstr "Langage (Vidéos)"
 msgctxt "#30052"
 msgid "Stream video quality"
 msgstr "Qualité vidéo préferée"
+
+msgctxt "#30053"
+msgid "Enable Subbed Version"
+msgstr "VOST"
+

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -18,6 +18,10 @@ msgctxt "#30052"
 msgid "Stream video quality"
 msgstr "Qualität des Videostreams"
 
+msgctxt "#30053"
+msgid "Original Subbed Version"
+msgstr "Original Subbed Version"
+
 msgctxt "#30005"
 msgid "Most recent"
 msgstr "Neuste"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -18,6 +18,10 @@ msgctxt "#30052"
 msgid "Stream video quality"
 msgstr ""
 
+msgctxt "#30053"
+msgid "Original Subbed Version"
+msgstr "Original Subbed Version"
+
 msgctxt "#30005"
 msgid "Most recent"
 msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -18,6 +18,10 @@ msgctxt "#30052"
 msgid "Stream video quality"
 msgstr "Qualité vidéo préferée"
 
+msgctxt "#30053"
+msgid "Original Subbed Version"
+msgstr "VOST"
+
 msgctxt "#30005"
 msgid "Most recent"
 msgstr "Les plus récentes"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -21,6 +21,8 @@
 #
 from xbmcswift2 import Plugin
 
+import re
+
 
 # global declarations
 # plugin stuff
@@ -31,15 +33,23 @@ class PluginInformation:
     name = plugin.name
     version = plugin.addon.getAddonInfo('version')
 
-
 # settings stuff
 languages = ['fr', 'de', 'en', 'es', 'pl']
+STOVAudioCodePatterns = {
+    'fr' : [ re.compile('VO.*-STF') ],
+    'de' : [ re.compile('VO.*-STA') ],
+    'en' : [ re.compile('VO-.*'), re.compile('VO.*-STE\\[ENG\\]') ],
+    'es' : [ re.compile('VOE\\[ESP\\]-.*'), re.compile('VO.*-STE\\[ESP\\]') ],
+    'pl' : [ re.compile('VOE\\[POL\\]-.*'), re.compile('VO.*-STE\\[POL\\]') ]
+    }
 qualities = ['SQ', 'EQ', 'HQ']
 
 # defaults to fr
 language = plugin.get_setting('lang', choices=languages) or languages[0]
 # defaults to SQ
 quality = plugin.get_setting('quality', choices=qualities) or qualities[0]
+# defaults to false
+stov = plugin.get_setting('stov', bool) or False
 
 # my imports
 import view
@@ -104,7 +114,7 @@ def collection(kind, collection_id):
 
 @plugin.route('/play/<kind>/<program_id>', name='play')
 def play(kind, program_id):
-    return plugin.set_resolved_url(view.build_stream_url(kind, program_id, language, quality))
+    return plugin.set_resolved_url(view.build_stream_url(kind, program_id, language, quality, stov, STOVAudioCodePatterns[language]))
 
 
 @plugin.route('/weekly', name='weekly')

--- a/resources/lib/mapper.py
+++ b/resources/lib/mapper.py
@@ -2,6 +2,7 @@ from addon import plugin
 
 import hof
 import utils
+import re
 
 
 def map_categories_item(item):
@@ -128,17 +129,27 @@ def map_playlist(config):
         }
     }
 
-
-def map_playable(streams, quality):
+def map_playable(streams, quality, STOV, STOVAudioPatterns):
     stream = None
     for q in [quality] + [i for i in ['SQ', 'EQ', 'HQ', 'MQ'] if i is not quality]:
-        stream = hof.find(lambda s: match(s, q), streams)
+        if STOV:
+            for p in STOVAudioPatterns:
+                stream = hof.find(lambda s: matchAudioCode(s, q, p), streams)
+                if stream:
+                    break
+
+        if not( stream ):
+            stream = hof.find(lambda s: match(s, q), streams)
+        
         if stream:
             break
+
     return {
         'path': stream.get('url')
     }
 
+def matchAudioCode(item, quality, codePattern):
+    return item.get('quality') == quality and codePattern.match(item.get('audioCode'))
 
 def match(item, quality):
     return item.get('quality') == quality and item.get('audioSlot') == 1

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -62,8 +62,8 @@ def build_mixed_collection(kind, collection_id, lang):
     return [mapper.map_generic_item(item) for item in api.collection(kind, collection_id, lang)]
 
 
-def build_stream_url(kind, program_id, lang, quality):
-    return mapper.map_playable(api.streams(kind, program_id, lang), quality)
+def build_stream_url(kind, program_id, lang, quality, STOV, STOVaudioCodePatterns):
+    return mapper.map_playable(api.streams(kind, program_id, lang), quality, STOV, STOVaudioCodePatterns)
 
 
 _useless_kinds = [ 'CLIP', 'MANUAL_CLIP', 'TRAILER' ]

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,4 +3,5 @@
     <setting id="lang"             type="enum"   label="30050" values="fr|de|en|es|pl" default="0"/>
     <!-- <setting id="prefer_vost"      type="bool"   label="30051" default="false"/> -->
     <setting id="quality"          type="enum"   label="30052" values="SQ (High)|EQ (Medium)|HQ (Low)" default="0"/>
+    <setting id="stov"             type="bool"   label="30053" default="false"/>
 </settings>


### PR DESCRIPTION
I added a bool option in the plugin settings. When checked, the rules to select the video to play changes : I tried to priorities VOST (original version with subtitles) version for the selected language if available rather than the dubbed version.
Tested only in french, german should be equivalent, other languages may not work.
Default behaviour remains the same so there should not be any regression (at least I hope so).