### PR TITLE
Added italian language support

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -11,7 +11,7 @@
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <summary lang="en">Arte +7</summary>
-        <language>fr de en</language>
+        <language>fr de en it</language>
         <description lang="fr">
 Regardez les vidéos de Arte +7
 Pour toute demande ou reporter un problème:
@@ -31,6 +31,13 @@ Watch videos from Arte +7
 For feature requests / issues:
 https://github.com/known-as-bmf/plugin.video.arteplussept/issues
 Contributions are welcome:
+https://github.com/known-as-bmf/plugin.video.arteplussept
+        </description>
+        <description lang="it">
+Guarda video da Arte +7
+Per richiedere nuove funzionalità o segnalare problemi:
+https://github.com/known-as-bmf/plugin.video.arteplussept/issues
+Nuovi contributi sono ben accetti:
 https://github.com/known-as-bmf/plugin.video.arteplussept
         </description>
         <license>MIT</license>

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -1,0 +1,19 @@
+# Kodi Media Center language file
+# Addon Name: Arte +7
+# Addon id: plugin.video.arteplussept
+# Addon Provider: bmf
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#30050"
+msgid "Language (Videos)"
+msgstr "Lingua (Video)"
+
+msgctxt "#30052"
+msgid "Stream video quality"
+msgstr "Qualità video"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -1,0 +1,31 @@
+# Kodi Media Center language file
+# Addon Name: Arte +7
+# Addon id: plugin.video.arteplussept
+# Addon Provider: bmf
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#30050"
+msgid "Language (Videos)"
+msgstr "Lingua (Video)"
+
+msgctxt "#30052"
+msgid "Stream video quality"
+msgstr "Qualità video"
+
+msgctxt "#30005"
+msgid "Most recent"
+msgstr "I più recenti"
+
+msgctxt "#30006"
+msgid "Most viewed"
+msgstr "I più visti"
+
+msgctxt "#30007"
+msgid "Last chance"
+msgstr "Ultima opportunità!"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -33,7 +33,7 @@ class PluginInformation:
 
 
 # settings stuff
-languages = ['fr', 'de', 'en', 'es', 'pl']
+languages = ['fr', 'de', 'en', 'es', 'pl', 'it']
 qualities = ['SQ', 'EQ', 'HQ']
 
 # defaults to fr

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <setting id="lang"             type="enum"   label="30050" values="fr|de|en|es|pl" default="0"/>
+    <setting id="lang"             type="enum"   label="30050" values="fr|de|en|es|pl|it" default="0"/>
     <!-- <setting id="prefer_vost"      type="bool"   label="30051" default="false"/> -->
     <setting id="quality"          type="enum"   label="30052" values="SQ (High)|EQ (Medium)|HQ (Low)" default="0"/>
 </settings>


### PR DESCRIPTION
I've added the Italian support for the add-on and for the arte.tv website.

It's my first contribution ever on a Kodi add-on and I've tested it only on my Kodi 18.2 installed on a Raspberry Pi 2, maybe further testing is needed...