### PR TITLE
return empty object instead of throwing error when JSON payload from …

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -74,5 +74,8 @@ def daily(date, lang):
 
 
 def _load_json(url, params=None, headers=_base_headers):
-    r = requests.get(_base_api_url + url, params=params, headers=headers)
-    return r.json(object_pairs_hook=OrderedDict)
+    try:
+        r = requests.get(_base_api_url + url, params=params, headers=headers)
+        return r.json(object_pairs_hook=OrderedDict)
+    except ValueError: # JSON decode failure (empty response ?)
+        return {}


### PR DESCRIPTION
…Arte API is invalid (e.g. in case of HTTP 500)