### PR TITLE
Add menu item to get favourite and last viewed video from Arte TV API  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.1.3
+
+- Added Polish translation
+- Added My list and My history content from Arte TV profile
+
 # Version 1.1.2
 
 - better date / locale handling & prevent crash when http error

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.2" provider-name="bmf">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.3" provider-name="bmf">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.xbmcswift2" version="19.0.4"/>
@@ -12,7 +12,7 @@
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <summary lang="en">Arte +7</summary>
-        <language>fr de en it</language>
+        <language>fr de en it pl</language>
         <description lang="fr">
 Regardez les vidéos de Arte +7
 Pour toute demande ou reporter un problème:
@@ -41,6 +41,13 @@ https://github.com/known-as-bmf/plugin.video.arteplussept/issues
 Nuovi contributi sono ben accetti:
 https://github.com/known-as-bmf/plugin.video.arteplussept
         </description>
+        <description lang="pl">
+Oglądaj wideos z Arte +7
+W przypadku problemów lub próśb o ulepszenie:
+https://github.com/known-as-bmf/plugin.video.arteplussept/issues
+Każda pomoc mile widziana:
+https://github.com/known-as-bmf/plugin.video.arteplussept
+        </description>
         <license>MIT</license>
         <source>https://github.com/known-as-bmf/plugin.video.arteplussept</source>
         <!--<forum></forum>
@@ -51,6 +58,9 @@ https://github.com/known-as-bmf/plugin.video.arteplussept
             <fanart>resources/fanart.jpg</fanart>
         </assets>
         <news>
+        v1.1.3
+        - Added Polish translation
+        - Added My list and My history content from Arte TV profile
         v1.1.2
         - better date / locale handling &amp; prevent crash when http error
         v1.1.1

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -10,6 +10,14 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+msgctxt "#30044"
+msgid "General"
+msgstr "Allgemein"
+
+msgctxt "#30045"
+msgid "Profile"
+msgstr "Profil"
+
 msgctxt "#30050"
 msgid "Language (Videos)"
 msgstr "Sprache (Videos)"
@@ -21,6 +29,14 @@ msgstr "Qualität des Videostreams"
 msgctxt "#30053"
 msgid "Show video stream options"
 msgstr "Show video stream options"
+
+msgctxt "#30054"
+msgid "Email"
+msgstr "E-Mail-Adresse"
+
+msgctxt "#30055"
+msgid "Password"
+msgstr "Passwort"
 
 msgctxt "#30005"
 msgid "Most recent"
@@ -41,3 +57,19 @@ msgstr "Sendungen A-Z"
 msgctxt "#30009"
 msgid "This week"
 msgstr "Diese Woche"
+
+msgctxt "#30010"
+msgid "My list"
+msgstr "Meine Liste"
+
+msgctxt "#30011"
+msgid "My history"
+msgstr "Mein Videoverlauf"
+
+msgctxt "#30020"
+msgid "Unable to authenticate"
+msgstr "Authentifizierungsfehler"
+
+msgctxt "#30021"
+msgid "Email or password missing"
+msgstr "E-Mail oder Passwort fehlen"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -10,6 +10,14 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+msgctxt "#30044"
+msgid "General"
+msgstr ""
+
+msgctxt "#30045"
+msgid "Profile"
+msgstr ""
+
 msgctxt "#30050"
 msgid "Language (Videos)"
 msgstr ""
@@ -20,6 +28,14 @@ msgstr ""
 
 msgctxt "#30053"
 msgid "Show video stream options"
+msgstr ""
+
+msgctxt "#30054"
+msgid "Email"
+msgstr ""
+
+msgctxt "#30055"
+msgid "Password"
 msgstr ""
 
 msgctxt "#30005"
@@ -40,4 +56,20 @@ msgstr ""
 
 msgctxt "#30009"
 msgid "This week"
+msgstr ""
+
+msgctxt "#30010"
+msgid "My list"
+msgstr ""
+
+msgctxt "#30011"
+msgid "My history"
+msgstr ""
+
+msgctxt "#30020"
+msgid "Unable to authenticate"
+msgstr ""
+
+msgctxt "#30021"
+msgid "Email or password missing"
 msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -10,6 +10,14 @@ msgstr ""
 "Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+msgctxt "#30044"
+msgid "General"
+msgstr "General"
+
+msgctxt "#30045"
+msgid "Profile"
+msgstr "Profil"
+
 msgctxt "#30050"
 msgid "Language (Videos)"
 msgstr "Langage (Vidéos)"
@@ -21,6 +29,14 @@ msgstr "Qualité vidéo préferée"
 msgctxt "#30053"
 msgid "Show video stream options"
 msgstr "Afficher les options de flux vidéo"
+
+msgctxt "#30054"
+msgid "Email"
+msgstr "Adresse e-mail"
+
+msgctxt "#30055"
+msgid "Password"
+msgstr "Mot de passe"
 
 msgctxt "#30005"
 msgid "Most recent"
@@ -41,3 +57,19 @@ msgstr "Émissions A-Z"
 msgctxt "#30009"
 msgid "This week"
 msgstr "Cette semaine"
+
+msgctxt "#30010"
+msgid "My list"
+msgstr "Mes favoris"
+
+msgctxt "#30011"
+msgid "My history"
+msgstr "Mon historique"
+
+msgctxt "#30020"
+msgid "Unable to authenticate"
+msgstr "Impossible de s'authentifier"
+
+msgctxt "#30021"
+msgid "Email or password missing"
+msgstr "E-mail ou mot de passe manquant"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -10,6 +10,14 @@ msgstr ""
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+msgctxt "#30044"
+msgid "General"
+msgstr "Generale"
+
+msgctxt "#30045"
+msgid "Profile"
+msgstr "Profilo"
+
 msgctxt "#30050"
 msgid "Language (Videos)"
 msgstr "Lingua (Video)"
@@ -21,6 +29,14 @@ msgstr "Qualità video"
 msgctxt "#30053"
 msgid "Show video stream options"
 msgstr "Show video stream options"
+
+msgctxt "#30054"
+msgid "Email"
+msgstr "Indirizzo email"
+
+msgctxt "#30055"
+msgid "Password"
+msgstr "Password"
 
 msgctxt "#30005"
 msgid "Most recent"
@@ -41,3 +57,19 @@ msgstr "Spettacoli A-Z"
 msgctxt "#30009"
 msgid "This week"
 msgstr "Questa settimana"
+
+msgctxt "#30010"
+msgid "My list"
+msgstr "La mia lista"
+
+msgctxt "#30011"
+msgid "My history"
+msgstr "Cronologia"
+
+msgctxt "#30020"
+msgid "Unable to authenticate"
+msgstr "Impossibile autenticare"
+
+msgctxt "#30021"
+msgid "Email or password missing"
+msgstr "E-mail o password mancanti"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -1,0 +1,75 @@
+# Kodi Media Center language file
+# Addon Name: Arte +7
+# Addon id: plugin.video.arteplussept
+# Addon Provider: bmf
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#30044"
+msgid "General"
+msgstr "Głowny"
+
+msgctxt "#30045"
+msgid "Profile"
+msgstr "Profil"
+
+msgctxt "#30050"
+msgid "Language (Videos)"
+msgstr "Język"
+
+msgctxt "#30052"
+msgid "Stream video quality"
+msgstr "Jakość wideo"
+
+msgctxt "#30053"
+msgid "Show video stream options"
+msgstr "Pokaz opcje wideo"
+
+msgctxt "#30054"
+msgid "Email"
+msgstr "E-mail"
+
+msgctxt "#30055"
+msgid "Password"
+msgstr "Hasło"
+
+msgctxt "#30005"
+msgid "Most recent"
+msgstr "Najnowsze"
+
+msgctxt "#30006"
+msgid "Most viewed"
+msgstr "Najczęściej oglądane"
+
+msgctxt "#30007"
+msgid "Last chance"
+msgstr "Opuszczajace oferte"
+
+msgctxt "#30008"
+msgid "Magazines A-Z"
+msgstr "Reportaże"
+
+msgctxt "#30009"
+msgid "This week"
+msgstr "W tym tygodniu"
+
+msgctxt "#30010"
+msgid "My list"
+msgstr "Moja lista"
+
+msgctxt "#30011"
+msgid "My history"
+msgstr "Ostatnio ogladane"
+
+msgctxt "#30020"
+msgid "Unable to authenticate"
+msgstr "Nie można uwierzytelnić"
+
+msgctxt "#30021"
+msgid "Email or password missing"
+msgstr "Brak e-mail lub hasła"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -19,6 +19,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+# https://xbmcswift2.readthedocs.io/en/latest/api.html
+# https://github.com/jbeluch/xbmcswift2
 from xbmcswift2 import Plugin
 
 
@@ -58,6 +60,18 @@ def category(category_code):
 def magazines():
     plugin.set_content('tvshows')
     return plugin.finish(view.build_magazines(settings))
+
+
+@plugin.route('/favorites', name='favorites')
+def favorites():
+    plugin.set_content('tvshows')
+    return plugin.finish(view.build_favorites(plugin, settings))
+
+
+@plugin.route('/last_viewed', name='last_viewed')
+def favorites():
+    plugin.set_content('tvshows')
+    return plugin.finish(view.build_last_viewed(plugin, settings))
 
 
 @plugin.route('/newest', name='newest')

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # https://xbmcswift2.readthedocs.io/en/latest/api.html
-# https://github.com/jbeluch/xbmcswift2
+# https://github.com/XBMC-Addons/script.module.xbmcswift2
 from xbmcswift2 import Plugin
 
 

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -1,10 +1,13 @@
 from collections import OrderedDict
 import requests
+import xbmc
 
 import hof
 
 from addon import PluginInformation
 
+
+# Arte hbbtv - deprecated API since 2022 prefer Arte TV API
 _base_api_url = 'http://www.arte.tv/hbbtvv2/services/web/index.php'
 _base_headers = {
     'user-agent': PluginInformation.name + '/' + PluginInformation.version
@@ -21,6 +24,30 @@ _endpoints = {
     'streams': '/OPA/v3/streams/{program_id}/{kind}/{lang}',
     'daily': '/OPA/v3/programs/{date}/{lang}'
 }
+
+
+# Arte TV API - Used on Arte TV website
+_artetv_url = 'https://api.arte.tv/api/sso/v3'
+_artetv_endpoints = {
+    'token': '/token', # POST
+    'favorites': '/favorites/{lang}?page={page}&limit={limit}', #GET
+    'last_viewed': '/lastvieweds/{lang}?page={page}&limit={limit}' #GET
+}
+_artetv_headers = {
+    'authorization': 'I6k2z58YGO08P1X0E8A7VBOjDxr8Lecg', # required to use token endpoint
+    'client': 'web', # required for Arte TV API
+    'accept': 'application/json'
+}
+
+# Retrieve favorites from a personal account.
+def favorites(plugin, lang, usr, pwd):
+    url = _artetv_url + _artetv_endpoints['favorites'].format(lang=lang, page='1', limit='50')
+    return _load_json_personal_content(plugin, url, usr, pwd)
+
+# Retrieve content recently watched by a user.
+def last_viewed(plugin, lang, usr, pwd):
+    url = _artetv_url + _artetv_endpoints['last_viewed'].format(lang=lang, page='1', limit='50')
+    return _load_json_personal_content(plugin, url, usr, pwd)
 
 
 def categories(lang):
@@ -72,10 +99,50 @@ def daily(date, lang):
     url = _endpoints['daily'].format(date=date, lang=lang)
     return _load_json(url).get('programs', [])
 
+# Deprecated since 2022. Prefer building url on client side
+def _load_json(path, headers=_base_headers):
+    url = _base_api_url + path
+    return _load_json_full_url(url, headers)
 
-def _load_json(url, params=None, headers=_base_headers):
+def _load_json_full_url(url, headers=_base_headers):
+    # https://requests.readthedocs.io/en/latest/
+    r = requests.get(url, headers=headers)
+    return r.json(object_pairs_hook=OrderedDict)
+
+# Get a bearer token and add it in headers before sending the request
+def _load_json_personal_content(plugin, url, usr, pwd, hdrs=_artetv_headers):
+    tkn = token(plugin, usr, pwd)
+    if not tkn:
+        return None
+    headers=hdrs.copy()
+    headers['authorization'] = tkn['token_type'] + ' ' + tkn['access_token']
+    return _load_json_full_url(url, headers).get('data', [])
+
+# Log in user thanks to his/her settings and get a bearer token
+# return None if:
+#   - any parameter is empty
+#     - silenty if both parameters are empty
+#     - with a notification if one is not empty
+#   - connection to arte tv failed
+def token(plugin, username="", password=""):
+    # unable to authenticate if either username or password are empty
+    if not username and not password:
+        return None
+    # inform that setings are incomplete
+    if not username or not password:
+        msg = plugin.addon.getLocalizedString(30020) + " : " + plugin.addon.getLocalizedString(30021)
+        plugin.notify(msg=msg, image='warning')
+        return None
+
+    url = _artetv_url + _artetv_endpoints['token']
+    token_data = {'anonymous_token': None, 'grant_type': 'password', 'username': username, 'password': password}
     try:
-        r = requests.get(_base_api_url + url, params=params, headers=headers)
-        return r.json(object_pairs_hook=OrderedDict)
-    except ValueError: # JSON decode failure (empty response ?)
-        return {}
+        # https://requests.readthedocs.io/en/latest/
+        r = requests.post(url, data=token_data, headers=_artetv_headers)
+    except requests.exceptions.ConnectionError as err:
+        # unable to auth. e.g.
+        # HTTPSConnectionPool(host='api.arte.tv', port=443): Max retries exceeded with url: /api/sso/v3/token
+        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
+        xbmc.log('Unable to authenticate to Arte TV : {err_str}'.format(err_str=err))
+        return None
+    return r.json(object_pairs_hook=OrderedDict)

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -17,3 +17,11 @@ class Settings:
         # defaults to False
         self.show_video_streams = plugin.get_setting(
             'show_video_streams', bool) or False
+		# Arte TV user name
+		# defaults to empty string to return false with if not str
+        self.username = plugin.get_setting(
+            'username') or ""
+		# Arte TV user password
+		# defaults to empty string to return false with if not str
+        self.password = plugin.get_setting(
+            'password') or ""

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -42,6 +42,15 @@ def parse_date(datestr):
     return date
 
 
+def parse_artetv_date(datestr):
+    date = None
+    try:
+        date = datetime.datetime.strptime(datestr, '%Y-%m-%dT%H:%M:%S%z') # 2022-07-01T03:00:00Z
+    except TypeError:
+        date = None
+    return date
+
+
 def past_week():
     today = datetime.date.today()
     one_day = datetime.timedelta(days=1)

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -7,12 +7,14 @@ import utils
 
 def build_categories(settings):
     categories = [
+        mapper.create_favorites_item(),
+        mapper.create_last_viewed_item(),
         mapper.create_newest_item(),
         mapper.create_most_viewed_item(),
         mapper.create_last_chance_item(),
     ]
-    categories.extend([mapper.map_categories_item(
-        item) for item in api.categories(settings.language)])
+    categories.extend([mapper.map_categories_item(item) for item in
+        api.categories(settings.language)])
     # categories.append(mapper.create_creative_item())
     categories.append(mapper.create_magazines_item())
     categories.append(mapper.create_week_item())
@@ -21,33 +23,49 @@ def build_categories(settings):
 
 
 def build_category(category_code, settings):
-    category = [mapper.map_category_item(
-        item, category_code) for item in api.category(category_code, settings.language)]
+    category = [mapper.map_category_item(item, category_code) for item in
+            api.category(category_code, settings.language)]
 
     return category
 
 
 def build_magazines(settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in api.magazines(settings.language)]
+    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
+            api.magazines(settings.language)]
+
+
+def build_favorites(plugin, settings):
+    return [mapper.map_artetv_video(item) for item in
+            api.favorites(plugin, settings.language, settings.username, settings.password) or
+            # display an empty list in case of error. error should be display in a notification
+            []]
+
+
+def build_last_viewed(plugin, settings):
+    return [mapper.map_artetv_video(item) for item in
+            api.last_viewed(plugin, settings.language, settings.username, settings.password) or
+            # display an empty list in case of error. error should be display in a notification
+            []]
 
 
 def build_newest(settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for
-            item in api.home_category('mostRecent', settings.language)]
+    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
+            api.home_category('mostRecent', settings.language)]
 
 
 def build_most_viewed(settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for
-            item in api.home_category('mostViewed', settings.language)]
+    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
+            api.home_category('mostViewed', settings.language)]
 
 
 def build_last_chance(settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for
-            item in api.home_category('lastChance', settings.language)]
+    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
+            api.home_category('lastChance', settings.language)]
 
 
 def build_sub_category_by_code(sub_category_code, settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in api.subcategory(sub_category_code, settings.language)]
+    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
+            api.subcategory(sub_category_code, settings.language)]
 
 
 def build_sub_category_by_title(category_code, sub_category_title, settings):
@@ -56,11 +74,13 @@ def build_sub_category_by_title(category_code, sub_category_title, settings):
 
     sub_category = hof.find(lambda i: i.get('title') == unquoted_title, category)
 
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in sub_category.get('teasers')]
+    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
+            sub_category.get('teasers')]
 
 
 def build_mixed_collection(kind, collection_id, settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in api.collection(kind, collection_id, settings.language)]
+    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
+            api.collection(kind, collection_id, settings.language)]
 
 
 def build_video_streams(program_id, settings):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,21 +1,38 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <setting
-        id="lang"
-        type="enum"
-        label="30050"
-        values="fr|de|en|es|pl|it"
-        default="0"/>
-    <!-- <setting id="prefer_vost"      type="bool"   label="30051" default="false"/> -->
-    <setting
-        id="quality"
-        type="enum"
-        label="30052"
-        values="SQ (High)|EQ (Medium)|HQ (Low)"
-        default="0"/>
-    <setting
-        id="show_video_streams"
-        type="bool"
-        label="30053"
-        default="false"/>
+
+    <!-- General -->
+    <category label="30044">
+		<setting
+			id="lang"
+			type="enum"
+			label="30050"
+			values="fr|de|en|es|pl|it"
+			default="0"/>
+		<!-- <setting id="prefer_vost"      type="bool"   label="30051" default="false"/> -->
+		<setting
+			id="quality"
+			type="enum"
+			label="30052"
+			values="SQ (High)|EQ (Medium)|HQ (Low)"
+			default="0"/>
+		<setting
+			id="show_video_streams"
+			type="bool"
+			label="30053"
+			default="false"/>
+	</category>
+	
+    <!-- Profile -->
+    <category label="30045">
+		<setting
+			id="username"
+			type="text"
+			label="30054" />
+		<setting
+			id="password"
+			type="text"
+			option="hidden"
+			label="30055" />
+	</category>
 </settings>


### PR DESCRIPTION
Add menu item to get favourite and last viewed video from Arte TV API to solve issue #78.

Summary of changes:
- Add 3 queries in api.py to support authentication, favourites and last viewed videos retrieval
- Add categories and fields in settings to store user and password
- Add 2 menu items at the top
    - They lead to empty list if email and password are not set in settings
    - If one of the 2 field is set but not the other a warning notification is displayed before empty list
    - If authentication fails, an error notification is displayed before empty list
- Add Polish translation (for existing and new text)
- Mark Arte HBBTV as deprecated in api.py module.

Possible enhancements:
- Modification of favourites through Kodi is not supported yet.
- Authentication requests may be optimized, by storing the bearer token in session rather than doing it for each menu item (requiring it : favourites and last viewed videos).
- Translation in Spanish